### PR TITLE
Add Mutual NDA Creator Next.js prototype [PL-3]

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "jest";
+import nextJest from "next/jest.js";
+
+const createJestConfig = nextJest({ dir: "./" });
+
+const config: Config = {
+  testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+  testMatch: ["**/__tests__/**/*.test.{ts,tsx}"],
+};
+
+export default createJestConfig(config);

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "prelegal-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "autoprefixer": "^10.0.1",
+    "postcss": "^8",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,20 +6,28 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
-    "next": "14.2.5",
+    "next": "^14.2.35",
     "react": "^18",
     "react-dom": "^18"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
+    "jest": "^30.2.0",
+    "jest-environment-jsdom": "^30.2.0",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
+    "ts-jest": "^29.4.6",
     "typescript": "^5"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/__tests__/MNDAPreview.test.tsx
+++ b/frontend/src/__tests__/MNDAPreview.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+import MNDAPreview from "@/components/MNDAPreview";
+import { MNDAFormData } from "@/lib/types";
+
+const baseData: MNDAFormData = {
+  purpose: "Evaluating a potential partnership",
+  effectiveDate: "2025-01-15",
+  mndaTermType: "expires",
+  mndaTermYears: "2",
+  confidentialityTermType: "fixed",
+  confidentialityTermYears: "3",
+  governingLaw: "Delaware",
+  jurisdiction: "Wilmington, Delaware",
+  party1: { name: "Alice Smith", title: "CEO", company: "Alpha Inc", noticeAddress: "1 Alpha St" },
+  party2: { name: "Bob Jones", title: "CTO", company: "Beta LLC", noticeAddress: "2 Beta Ave" },
+};
+
+describe("MNDAPreview", () => {
+  it("renders the MNDA title", () => {
+    render(<MNDAPreview data={baseData} />);
+    expect(screen.getByRole("heading", { name: /mutual non-disclosure agreement/i })).toBeInTheDocument();
+  });
+
+  it("renders the purpose in the cover page and standard terms", () => {
+    render(<MNDAPreview data={baseData} />);
+    const instances = screen.getAllByText(/Evaluating a potential partnership/);
+    // Appears in cover page section and at least once in Standard Terms
+    expect(instances.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders formatted effective date", () => {
+    render(<MNDAPreview data={baseData} />);
+    expect(screen.getAllByText(/January 15, 2025/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders expires term text when mndaTermType is 'expires'", () => {
+    render(<MNDAPreview data={baseData} />);
+    expect(screen.getByText(/Expires 2 years from Effective Date/)).toBeInTheDocument();
+  });
+
+  it("renders ongoing term text when mndaTermType is 'ongoing'", () => {
+    render(<MNDAPreview data={{ ...baseData, mndaTermType: "ongoing" }} />);
+    expect(
+      screen.getByText(/Continues until terminated in accordance with the terms of the MNDA/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders singular 'year' for mndaTermYears = 1", () => {
+    render(<MNDAPreview data={{ ...baseData, mndaTermYears: "1" }} />);
+    expect(screen.getByText(/Expires 1 year from Effective Date/)).toBeInTheDocument();
+    expect(screen.queryByText(/Expires 1 years/)).not.toBeInTheDocument();
+  });
+
+  it("renders fixed confidentiality text with year count", () => {
+    render(<MNDAPreview data={baseData} />);
+    expect(screen.getByText(/3 years from Effective Date/)).toBeInTheDocument();
+  });
+
+  it("renders perpetuity confidentiality text", () => {
+    render(
+      <MNDAPreview data={{ ...baseData, confidentialityTermType: "perpetuity" }} />
+    );
+    expect(screen.getByText(/In perpetuity\./)).toBeInTheDocument();
+  });
+
+  it("renders governing law and jurisdiction", () => {
+    render(<MNDAPreview data={baseData} />);
+    expect(screen.getAllByText(/Delaware/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/Wilmington, Delaware/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders both party names and companies in signature block", () => {
+    render(<MNDAPreview data={baseData} />);
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    expect(screen.getByText("Alpha Inc")).toBeInTheDocument();
+    expect(screen.getByText("Bob Jones")).toBeInTheDocument();
+    expect(screen.getByText("Beta LLC")).toBeInTheDocument();
+  });
+
+  it("renders blank signature date lines instead of pre-filled dates", () => {
+    render(<MNDAPreview data={baseData} />);
+    const dateLines = screen.getAllByText("_______________");
+    // Should have blanks for: name, title, company, notice address (x2 parties) + date fields
+    expect(dateLines.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders fallback placeholders when fields are empty", () => {
+    const emptyData: MNDAFormData = {
+      ...baseData,
+      purpose: "",
+      governingLaw: "",
+      jurisdiction: "",
+    };
+    render(<MNDAPreview data={emptyData} />);
+    expect(screen.getAllByText("[Purpose]").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/\[State\]/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/\[Jurisdiction\]/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders standard terms section heading", () => {
+    render(<MNDAPreview data={baseData} />);
+    expect(screen.getByRole("heading", { name: /standard terms/i })).toBeInTheDocument();
+  });
+
+  it("renders all 11 standard term clauses", () => {
+    const { container } = render(<MNDAPreview data={baseData} />);
+    const listItems = container.querySelectorAll("ol > li");
+    expect(listItems).toHaveLength(11);
+  });
+});

--- a/frontend/src/__tests__/types.test.ts
+++ b/frontend/src/__tests__/types.test.ts
@@ -1,0 +1,25 @@
+import { defaultFormData } from "@/lib/types";
+
+describe("defaultFormData", () => {
+  it("has expected default values", () => {
+    expect(defaultFormData.mndaTermType).toBe("expires");
+    expect(defaultFormData.mndaTermYears).toBe("1");
+    expect(defaultFormData.confidentialityTermType).toBe("fixed");
+    expect(defaultFormData.confidentialityTermYears).toBe("1");
+  });
+
+  it("has empty effectiveDate so components set it lazily", () => {
+    expect(defaultFormData.effectiveDate).toBe("");
+  });
+
+  it("has empty party fields", () => {
+    expect(defaultFormData.party1.name).toBe("");
+    expect(defaultFormData.party1.company).toBe("");
+    expect(defaultFormData.party2.name).toBe("");
+    expect(defaultFormData.party2.company).toBe("");
+  });
+
+  it("has a non-empty default purpose", () => {
+    expect(defaultFormData.purpose.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@media print {
+  .no-print {
+    display: none !important;
+  }
+  body {
+    font-size: 12pt;
+  }
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Mutual NDA Creator | Prelegal",
+  description: "Create a customised Mutual Non-Disclosure Agreement in minutes",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="bg-gray-50 text-gray-900 antialiased">{children}</body>
+    </html>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { MNDAFormData, defaultFormData, PartyDetails } from "@/lib/types";
+
+function PartySection({
+  label,
+  party,
+  onChange,
+}: {
+  label: string;
+  party: PartyDetails;
+  onChange: (field: keyof PartyDetails, value: string) => void;
+}) {
+  return (
+    <div className="border border-gray-200 rounded-lg p-4">
+      <h3 className="font-semibold text-gray-700 mb-3">{label}</h3>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Full Name / Signatory Name
+          </label>
+          <input
+            type="text"
+            value={party.name}
+            onChange={(e) => onChange("name", e.target.value)}
+            placeholder="Jane Smith"
+            className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Title
+          </label>
+          <input
+            type="text"
+            value={party.title}
+            onChange={(e) => onChange("title", e.target.value)}
+            placeholder="CEO"
+            className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Company Name
+          </label>
+          <input
+            type="text"
+            value={party.company}
+            onChange={(e) => onChange("company", e.target.value)}
+            placeholder="Acme Corp"
+            className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Notice Address
+          </label>
+          <input
+            type="text"
+            value={party.noticeAddress}
+            onChange={(e) => onChange("noticeAddress", e.target.value)}
+            placeholder="123 Main St, City, State 12345"
+            className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function HomePage() {
+  const router = useRouter();
+  const [form, setForm] = useState<MNDAFormData>(defaultFormData);
+
+  function setField<K extends keyof MNDAFormData>(key: K, value: MNDAFormData[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function setPartyField(
+    party: "party1" | "party2",
+    field: keyof PartyDetails,
+    value: string
+  ) {
+    setForm((prev) => ({
+      ...prev,
+      [party]: { ...prev[party], [field]: value },
+    }));
+  }
+
+  function handlePreview() {
+    localStorage.setItem("mndaFormData", JSON.stringify(form));
+    router.push("/preview");
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 py-10 px-4">
+      <div className="max-w-2xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">
+            Mutual NDA Creator
+          </h1>
+          <p className="mt-2 text-gray-500 text-sm">
+            Fill in the details below to generate your Mutual Non-Disclosure
+            Agreement based on the{" "}
+            <a
+              href="https://commonpaper.com/standards/mutual-nda/"
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+            >
+              Common Paper standard
+            </a>
+            .
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          {/* Purpose */}
+          <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
+            <h2 className="font-semibold text-gray-800 mb-3">Purpose</h2>
+            <p className="text-xs text-gray-500 mb-2">
+              How Confidential Information may be used
+            </p>
+            <textarea
+              rows={3}
+              value={form.purpose}
+              onChange={(e) => setField("purpose", e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            />
+          </section>
+
+          {/* Effective Date */}
+          <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
+            <h2 className="font-semibold text-gray-800 mb-3">Effective Date</h2>
+            <input
+              type="date"
+              value={form.effectiveDate}
+              onChange={(e) => setField("effectiveDate", e.target.value)}
+              className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </section>
+
+          {/* MNDA Term */}
+          <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
+            <h2 className="font-semibold text-gray-800 mb-1">MNDA Term</h2>
+            <p className="text-xs text-gray-500 mb-3">
+              The length of this MNDA
+            </p>
+            <div className="flex flex-col gap-2">
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="mndaTermType"
+                  value="expires"
+                  checked={form.mndaTermType === "expires"}
+                  onChange={() => setField("mndaTermType", "expires")}
+                  className="accent-blue-600"
+                />
+                Expires after a fixed number of years
+              </label>
+              {form.mndaTermType === "expires" && (
+                <div className="ml-6 flex items-center gap-2">
+                  <input
+                    type="number"
+                    min={1}
+                    max={10}
+                    value={form.mndaTermYears}
+                    onChange={(e) => setField("mndaTermYears", e.target.value)}
+                    className="w-20 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  <span className="text-sm text-gray-600">year(s)</span>
+                </div>
+              )}
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="mndaTermType"
+                  value="ongoing"
+                  checked={form.mndaTermType === "ongoing"}
+                  onChange={() => setField("mndaTermType", "ongoing")}
+                  className="accent-blue-600"
+                />
+                Ongoing (until terminated)
+              </label>
+            </div>
+          </section>
+
+          {/* Term of Confidentiality */}
+          <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
+            <h2 className="font-semibold text-gray-800 mb-1">
+              Term of Confidentiality
+            </h2>
+            <p className="text-xs text-gray-500 mb-3">
+              How long Confidential Information is protected
+            </p>
+            <div className="flex flex-col gap-2">
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="confidentialityTermType"
+                  value="fixed"
+                  checked={form.confidentialityTermType === "fixed"}
+                  onChange={() => setField("confidentialityTermType", "fixed")}
+                  className="accent-blue-600"
+                />
+                Fixed number of years from Effective Date
+              </label>
+              {form.confidentialityTermType === "fixed" && (
+                <div className="ml-6 flex items-center gap-2">
+                  <input
+                    type="number"
+                    min={1}
+                    max={20}
+                    value={form.confidentialityTermYears}
+                    onChange={(e) =>
+                      setField("confidentialityTermYears", e.target.value)
+                    }
+                    className="w-20 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  <span className="text-sm text-gray-600">year(s)</span>
+                </div>
+              )}
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="confidentialityTermType"
+                  value="perpetuity"
+                  checked={form.confidentialityTermType === "perpetuity"}
+                  onChange={() =>
+                    setField("confidentialityTermType", "perpetuity")
+                  }
+                  className="accent-blue-600"
+                />
+                In perpetuity
+              </label>
+            </div>
+          </section>
+
+          {/* Governing Law & Jurisdiction */}
+          <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
+            <h2 className="font-semibold text-gray-800 mb-3">
+              Governing Law &amp; Jurisdiction
+            </h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">
+                  Governing Law (State)
+                </label>
+                <input
+                  type="text"
+                  value={form.governingLaw}
+                  onChange={(e) => setField("governingLaw", e.target.value)}
+                  placeholder="e.g. Delaware"
+                  className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">
+                  Jurisdiction
+                </label>
+                <input
+                  type="text"
+                  value={form.jurisdiction}
+                  onChange={(e) => setField("jurisdiction", e.target.value)}
+                  placeholder="e.g. Wilmington, Delaware"
+                  className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* Parties */}
+          <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
+            <h2 className="font-semibold text-gray-800 mb-4">Parties</h2>
+            <div className="space-y-4">
+              <PartySection
+                label="Party 1"
+                party={form.party1}
+                onChange={(field, value) =>
+                  setPartyField("party1", field, value)
+                }
+              />
+              <PartySection
+                label="Party 2"
+                party={form.party2}
+                onChange={(field, value) =>
+                  setPartyField("party2", field, value)
+                }
+              />
+            </div>
+          </section>
+
+          <button
+            onClick={handlePreview}
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 rounded-xl text-sm transition-colors"
+          >
+            Preview &amp; Download NDA →
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/preview/page.tsx
+++ b/frontend/src/app/preview/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { MNDAFormData, defaultFormData } from "@/lib/types";
+import MNDAPreview from "@/components/MNDAPreview";
+
+export default function PreviewPage() {
+  const router = useRouter();
+  const [data, setData] = useState<MNDAFormData>(defaultFormData);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("mndaFormData");
+    if (stored) {
+      try {
+        setData(JSON.parse(stored));
+      } catch {
+        // fall back to defaults
+      }
+    }
+  }, []);
+
+  function handleDownload() {
+    window.print();
+  }
+
+  return (
+    <>
+      {/* Toolbar — hidden when printing */}
+      <div className="no-print sticky top-0 z-10 bg-white border-b border-gray-200 shadow-sm px-4 py-3 flex items-center justify-between">
+        <button
+          onClick={() => router.push("/")}
+          className="text-sm text-gray-600 hover:text-gray-900 flex items-center gap-1"
+        >
+          ← Back to form
+        </button>
+        <button
+          onClick={handleDownload}
+          className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
+        >
+          Download PDF
+        </button>
+      </div>
+
+      {/* Document */}
+      <div className="py-10 px-4 bg-gray-50 min-h-screen">
+        <div className="bg-white shadow-sm rounded-xl border border-gray-200 p-8 max-w-3xl mx-auto">
+          <MNDAPreview data={data} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/MNDAPreview.tsx
+++ b/frontend/src/components/MNDAPreview.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { MNDAFormData } from "@/lib/types";
 
 interface Props {
@@ -141,7 +139,7 @@ export default function MNDAPreview({ data }: Props) {
                   </p>
                   <p>
                     <span className="text-xs text-gray-400">Date: </span>
-                    {formatDate(effectiveDate)}
+                    {"_______________"}
                   </p>
                 </div>
               </div>

--- a/frontend/src/components/MNDAPreview.tsx
+++ b/frontend/src/components/MNDAPreview.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { MNDAFormData } from "@/lib/types";
+
+interface Props {
+  data: MNDAFormData;
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return "[Date]";
+  const d = new Date(iso + "T00:00:00");
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export default function MNDAPreview({ data }: Props) {
+  const {
+    purpose,
+    effectiveDate,
+    mndaTermType,
+    mndaTermYears,
+    confidentialityTermType,
+    confidentialityTermYears,
+    governingLaw,
+    jurisdiction,
+    party1,
+    party2,
+  } = data;
+
+  const termText =
+    mndaTermType === "expires"
+      ? `Expires ${mndaTermYears} year${Number(mndaTermYears) !== 1 ? "s" : ""} from Effective Date.`
+      : "Continues until terminated in accordance with the terms of the MNDA.";
+
+  const confidentialityText =
+    confidentialityTermType === "fixed"
+      ? `${confidentialityTermYears} year${Number(confidentialityTermYears) !== 1 ? "s" : ""} from Effective Date, but in the case of trade secrets until Confidential Information is no longer considered a trade secret under applicable laws.`
+      : "In perpetuity.";
+
+  return (
+    <div className="font-serif text-sm leading-relaxed text-gray-900 max-w-3xl mx-auto">
+      {/* Cover Page */}
+      <h1 className="text-2xl font-bold text-center mb-6">
+        Mutual Non-Disclosure Agreement
+      </h1>
+
+      <p className="mb-4 text-xs text-gray-600">
+        This Mutual Non-Disclosure Agreement (the &ldquo;MNDA&rdquo;) consists
+        of: (1) this Cover Page and (2) the Common Paper Mutual NDA Standard
+        Terms Version 1.0. Any modifications of the Standard Terms should be
+        made on the Cover Page, which will control over conflicts with the
+        Standard Terms.
+      </p>
+
+      <div className="space-y-5 mb-8">
+        <section>
+          <h2 className="font-bold text-base border-b border-gray-300 pb-1 mb-2">
+            Purpose
+          </h2>
+          <p className="text-xs text-gray-500 italic mb-1">
+            How Confidential Information may be used
+          </p>
+          <p>{purpose || "[Purpose]"}</p>
+        </section>
+
+        <section>
+          <h2 className="font-bold text-base border-b border-gray-300 pb-1 mb-2">
+            Effective Date
+          </h2>
+          <p>{formatDate(effectiveDate)}</p>
+        </section>
+
+        <section>
+          <h2 className="font-bold text-base border-b border-gray-300 pb-1 mb-2">
+            MNDA Term
+          </h2>
+          <p className="text-xs text-gray-500 italic mb-1">
+            The length of this MNDA
+          </p>
+          <p>{termText}</p>
+        </section>
+
+        <section>
+          <h2 className="font-bold text-base border-b border-gray-300 pb-1 mb-2">
+            Term of Confidentiality
+          </h2>
+          <p className="text-xs text-gray-500 italic mb-1">
+            How long Confidential Information is protected
+          </p>
+          <p>{confidentialityText}</p>
+        </section>
+
+        <section>
+          <h2 className="font-bold text-base border-b border-gray-300 pb-1 mb-2">
+            Governing Law &amp; Jurisdiction
+          </h2>
+          <p>
+            <strong>Governing Law:</strong> {governingLaw || "[State]"}
+          </p>
+          <p>
+            <strong>Jurisdiction:</strong> {jurisdiction || "[Jurisdiction]"}
+          </p>
+        </section>
+
+        {/* Signature block */}
+        <section>
+          <h2 className="font-bold text-base border-b border-gray-300 pb-1 mb-3">
+            Signatures
+          </h2>
+          <div className="grid grid-cols-2 gap-6 text-sm">
+            {[
+              { label: "Party 1", party: party1 },
+              { label: "Party 2", party: party2 },
+            ].map(({ label, party }) => (
+              <div key={label} className="border border-gray-200 p-3 rounded">
+                <p className="font-semibold mb-2 text-center">{label}</p>
+                <div className="space-y-2">
+                  <div className="border-b border-gray-300 pb-4 mb-1">
+                    <p className="text-xs text-gray-400">Signature</p>
+                  </div>
+                  <p>
+                    <span className="text-xs text-gray-400">Print Name: </span>
+                    {party.name || "_______________"}
+                  </p>
+                  <p>
+                    <span className="text-xs text-gray-400">Title: </span>
+                    {party.title || "_______________"}
+                  </p>
+                  <p>
+                    <span className="text-xs text-gray-400">Company: </span>
+                    {party.company || "_______________"}
+                  </p>
+                  <p>
+                    <span className="text-xs text-gray-400">
+                      Notice Address:{" "}
+                    </span>
+                    {party.noticeAddress || "_______________"}
+                  </p>
+                  <p>
+                    <span className="text-xs text-gray-400">Date: </span>
+                    {formatDate(effectiveDate)}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      {/* Standard Terms */}
+      <div className="border-t-2 border-gray-400 pt-6">
+        <h2 className="text-xl font-bold text-center mb-4">Standard Terms</h2>
+
+        <ol className="list-decimal list-outside pl-5 space-y-4 text-sm">
+          <li>
+            <strong>Introduction.</strong> This Mutual Non-Disclosure Agreement
+            (which incorporates these Standard Terms and the Cover Page)
+            (&ldquo;MNDA&rdquo;) allows each party (&ldquo;Disclosing
+            Party&rdquo;) to disclose or make available information in
+            connection with the <em>{purpose || "[Purpose]"}</em> which (1) the
+            Disclosing Party identifies to the receiving party (&ldquo;Receiving
+            Party&rdquo;) as &ldquo;confidential&rdquo;,
+            &ldquo;proprietary&rdquo;, or the like or (2) should be reasonably
+            understood as confidential or proprietary due to its nature and the
+            circumstances of its disclosure (&ldquo;Confidential
+            Information&rdquo;). Each party&rsquo;s Confidential Information
+            also includes the existence and status of the parties&rsquo;
+            discussions and information on the Cover Page.
+          </li>
+          <li>
+            <strong>Use and Protection of Confidential Information.</strong> The
+            Receiving Party shall: (a) use Confidential Information solely for
+            the <em>{purpose || "[Purpose]"}</em>; (b) not disclose Confidential
+            Information to third parties without the Disclosing Party&rsquo;s
+            prior written approval, except that the Receiving Party may disclose
+            Confidential Information to its employees, agents, advisors,
+            contractors and other representatives having a reasonable need to
+            know; and (c) protect Confidential Information using at least the
+            same protections the Receiving Party uses for its own similar
+            information but no less than a reasonable standard of care.
+          </li>
+          <li>
+            <strong>Exceptions.</strong> The Receiving Party&rsquo;s obligations
+            do not apply to information that: (a) is or becomes publicly
+            available through no fault of the Receiving Party; (b) it rightfully
+            knew or possessed prior to receipt without confidentiality
+            restrictions; (c) it rightfully obtained from a third party without
+            confidentiality restrictions; or (d) it independently developed
+            without using or referencing the Confidential Information.
+          </li>
+          <li>
+            <strong>Disclosures Required by Law.</strong> The Receiving Party
+            may disclose Confidential Information to the extent required by law,
+            provided (to the extent legally permitted) it provides the
+            Disclosing Party reasonable advance notice and reasonably cooperates
+            with efforts to obtain confidential treatment.
+          </li>
+          <li>
+            <strong>Term and Termination.</strong> This MNDA commences on{" "}
+            {formatDate(effectiveDate)} and{" "}
+            {mndaTermType === "expires"
+              ? `expires ${mndaTermYears} year${Number(mndaTermYears) !== 1 ? "s" : ""} from the Effective Date`
+              : "continues until terminated"}
+            . Either party may terminate this MNDA for any or no reason upon
+            written notice to the other party. The Receiving Party&rsquo;s
+            obligations relating to Confidential Information will survive for{" "}
+            {confidentialityText.toLowerCase()}
+          </li>
+          <li>
+            <strong>Return or Destruction of Confidential Information.</strong>{" "}
+            Upon expiration or termination, the Receiving Party will: (a) cease
+            using Confidential Information; (b) promptly destroy or return all
+            Confidential Information; and (c) if requested, confirm compliance
+            in writing.
+          </li>
+          <li>
+            <strong>Proprietary Rights.</strong> The Disclosing Party retains
+            all intellectual property and other rights in its Confidential
+            Information and its disclosure grants no license under such rights.
+          </li>
+          <li>
+            <strong>Disclaimer.</strong> ALL CONFIDENTIAL INFORMATION IS
+            PROVIDED &ldquo;AS IS&rdquo;, WITH ALL FAULTS, AND WITHOUT
+            WARRANTIES, INCLUDING THE IMPLIED WARRANTIES OF TITLE,
+            MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+          </li>
+          <li>
+            <strong>Governing Law and Jurisdiction.</strong> This MNDA is
+            governed by the laws of the State of{" "}
+            <strong>{governingLaw || "[State]"}</strong>. Any legal proceedings
+            must be instituted in the courts located in{" "}
+            <strong>{jurisdiction || "[Jurisdiction]"}</strong>.
+          </li>
+          <li>
+            <strong>Equitable Relief.</strong> A breach of this MNDA may cause
+            irreparable harm for which monetary damages are an insufficient
+            remedy. The Disclosing Party is entitled to seek appropriate
+            equitable relief, including an injunction.
+          </li>
+          <li>
+            <strong>General.</strong> Neither party may assign this MNDA without
+            prior written consent, except in connection with a merger,
+            reorganization, acquisition or transfer of all or substantially all
+            assets or voting securities. This MNDA constitutes the entire
+            agreement of the parties with respect to its subject matter.
+          </li>
+        </ol>
+
+        <p className="mt-6 text-xs text-gray-400 text-center">
+          Common Paper Mutual Non-Disclosure Agreement Version 1.0 — free to
+          use under{" "}
+          <a
+            href="https://creativecommons.org/licenses/by/4.0/"
+            className="underline"
+          >
+            CC BY 4.0
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -12,9 +16,26 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
-    "paths": { "@/*": ["./src/*"] }
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "target": "ES2017"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

- Next.js 14 app (TypeScript + Tailwind CSS) in `frontend/` directory
- **Form page** (`/`): collects all MNDA fields — purpose, effective date, MNDA term (fixed or ongoing), term of confidentiality (fixed or perpetuity), governing law & jurisdiction, and Party 1 & 2 details
- **Preview page** (`/preview`): renders the complete Common Paper Mutual NDA v1.0 with all user values interpolated into the cover page and standard terms
- **Download**: uses `window.print()` with `@media print` CSS to produce a clean PDF with UI chrome hidden

## Test plan

- [ ] Run `npm install && npm run dev` from `frontend/`
- [ ] Fill out the form and click "Preview & Download NDA"
- [ ] Verify all entered values appear correctly in the document
- [ ] Click "Download PDF" and confirm browser print dialog opens with a clean document (no toolbar)
- [ ] Verify "Back to form" navigates back with the form pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)